### PR TITLE
More foolproofing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Mod Organizer Umbrella stuff
+/msbuild.log
+/*std*.log
+/*build
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/FNISPatches.py
+++ b/src/FNISPatches.py
@@ -88,7 +88,7 @@ class FNISPatches(mobase.IPluginTool):
         return mobase.VersionInfo(1, 0, 0, mobase.ReleaseType.prealpha)
 
     def isActive(self):
-        return True
+        return self.__organizer.managedGame().gameName() in patchListNames.keys()
 
     def settings(self):
         return []

--- a/src/FNISTool.py
+++ b/src/FNISTool.py
@@ -59,7 +59,12 @@ class FNISTool(mobase.IPluginTool):
         return mobase.VersionInfo(1, 0, 0, mobase.ReleaseType.prealpha)
 
     def isActive(self):
-        return True
+        supportedGames = {
+            "Skyrim",
+            "Skyrim Special Edition",
+            "Skyrim VR"
+        }
+        return self.__organizer.managedGame().gameName() in supportedGames
 
     def settings(self):
         return [

--- a/src/FNISTool.py
+++ b/src/FNISTool.py
@@ -16,7 +16,7 @@ import os
 import pathlib
 import sys
 
-from PyQt5.QtCore import QCoreApplication, qCritical, qDebug, QFileInfo
+from PyQt5.QtCore import QCoreApplication, qCritical, QFileInfo
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QFileDialog, QFileSystemModel, QMessageBox
 
@@ -111,9 +111,6 @@ class FNISTool(mobase.IPluginTool):
             return
         handle = self.__organizer.startApplication(executable, args)
         result, exitCode = self.__organizer.waitForApplication(handle)
-        qDebug(str(handle))
-        qDebug(str(result))
-        qDebug(str(exitCode))
     
     def __tr(self, str):
         return QCoreApplication.translate("FNISTool", str)

--- a/src/FNISTool.py
+++ b/src/FNISTool.py
@@ -138,16 +138,18 @@ class FNISTool(mobase.IPluginTool):
     
     def __getOutputPath(self):
         path = self.__organizer.pluginSetting(self.name(), "output-path")
+        pathlibPath = pathlib.Path(path)
         modDirectory = self.__getModDirectory()
-        isAMod = pathlib.Path(path).parent.samefile(modDirectory)
-        if not os.path.isdir(path) or not isAMod:
+        isAMod = pathlibPath.parent.samefile(modDirectory)
+        if not pathlibPath.is_dir() or not isAMod:
             QMessageBox.information(self.__parentWidget, self.__tr("Choose an output mod"), self.__tr("Please choose an output mod for Fore's New Idles in Skyrim. This must be a directory in Mod Organizer's mods directory, and you can create one if you do not have one already. FNIS will delete any existing contents of this directory when it is run, so do not choose a mod you use for anything else. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu."))
-            while not os.path.isdir(path) or not isAMod:
+            while not pathlibPath.is_dir() or not isAMod:
                 path = QFileDialog.getExistingDirectory(self.__parentWidget, self.__tr("Choose an output mod"), str(modDirectory), QFileDialog.ShowDirsOnly)
-                if not os.path.isdir(path):
+                pathlibPath = pathlib.Path(path)
+                if not pathlibPath.is_dir():
                     # cancel was pressed
                     raise UnknownOutputPreferenceException
-                isAMod = pathlib.Path(path).parent.samefile(modDirectory)
+                isAMod = pathlibPath.parent.samefile(modDirectory)
                 if not isAMod:
                     QMessageBox.information(self.__parentWidget, self.__tr("Not a mod..."), self.__tr("The selected directory is not a Mod Organizer managed mod. Please choose a directory within the mods directory."))
             # The user may have created a new mod in the MO mods directory, so we must trigger a refresh

--- a/src/FNISTool.py
+++ b/src/FNISTool.py
@@ -142,7 +142,7 @@ class FNISTool(mobase.IPluginTool):
         modDirectory = self.__getModDirectory()
         isAMod = pathlibPath.parent.samefile(modDirectory)
         if not pathlibPath.is_dir() or not isAMod:
-            QMessageBox.information(self.__parentWidget, self.__tr("Choose an output mod"), self.__tr("Please choose an output mod for Fore's New Idles in Skyrim. This must be a directory in Mod Organizer's mods directory, and you can create one if you do not have one already. FNIS will delete any existing contents of this directory when it is run, so do not choose a mod you use for anything else. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu."))
+            QMessageBox.information(self.__parentWidget, self.__tr("Choose an output mod"), self.__tr("Please choose an output mod for Fore's New Idles in Skyrim. This must be a directory in Mod Organizer's mods directory, and you can create one if you do not have one already. This mod will not be available to the VFS when FNIS is run, so do not choose a mod you use for anything else. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu."))
             while not pathlibPath.is_dir() or not isAMod:
                 path = QFileDialog.getExistingDirectory(self.__parentWidget, self.__tr("Choose an output mod"), str(modDirectory), QFileDialog.ShowDirsOnly)
                 pathlibPath = pathlib.Path(path)
@@ -152,6 +152,19 @@ class FNISTool(mobase.IPluginTool):
                 isAMod = pathlibPath.parent.samefile(modDirectory)
                 if not isAMod:
                     QMessageBox.information(self.__parentWidget, self.__tr("Not a mod..."), self.__tr("The selected directory is not a Mod Organizer managed mod. Please choose a directory within the mods directory."))
+                    continue
+                empty = True
+                for item in pathlibPath.iterdir():
+                    if item.name != "meta.ini":
+                        empty = False
+                        break
+                if not empty:
+                    if QMessageBox.question(self.__parentWidget, self.__tr("Mod not empty"), self.__tr("The selected mod already contains files. Are you sure want to use it as the output mod?"), QMessageBox.StandardButtons(QMessageBox.Yes | QMessageBox.No)) == QMessageBox.Yes:
+                        # Proceed normally - the user is happy
+                        pass
+                    else:
+                        # Restart outer loop - the user wants to pick again
+                        isAMod = False
             # The user may have created a new mod in the MO mods directory, so we must trigger a refresh
             self.__organizer.refreshModList()
             self.__organizer.setPluginSetting(self.name(), "output-path", path)

--- a/src/FNISTool_en.ts
+++ b/src/FNISTool_en.ts
@@ -141,48 +141,48 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="146"/>
+        <location filename="FNISTool.py" line="147"/>
         <source>Choose an output mod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="144"/>
-        <source>Please choose an output mod for Fore&apos;s New Idles in Skyrim. This must be a directory in Mod Organizer&apos;s mods directory, and you can create one if you do not have one already. FNIS will delete any existing contents of this directory when it is run, so do not choose a mod you use for anything else. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="FNISTool.py" line="152"/>
+        <location filename="FNISTool.py" line="154"/>
         <source>Not a mod...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="152"/>
+        <location filename="FNISTool.py" line="154"/>
         <source>The selected directory is not a Mod Organizer managed mod. Please choose a directory within the mods directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="167"/>
+        <location filename="FNISTool.py" line="172"/>
         <source>Find FNIS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="167"/>
+        <location filename="FNISTool.py" line="172"/>
         <source>Fore&apos;s New Idles in Skyrim can&apos;t be found using the location saved in Mod Organizer&apos;s settings. Please find GenerateFNISforUsers.exe in the file picker. FNIS must be visible within the VFS, so choose an installation either within the game&apos;s data directory or within a mod folder. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="169"/>
+        <location filename="FNISTool.py" line="174"/>
         <source>Locate GenerateFNISforUsers.exe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="181"/>
+        <location filename="FNISTool.py" line="186"/>
         <source>Not a compatible location...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="FNISTool.py" line="181"/>
+        <location filename="FNISTool.py" line="186"/>
         <source>Fore&apos;s New Idles in Skyrim only works when within the VFS, so must be installed to the game&apos;s data directory or within a mod folder. Please select a different FNIS installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="FNISTool.py" line="145"/>
+        <source>Please choose an output mod for Fore&apos;s New Idles in Skyrim. This must be a directory in Mod Organizer&apos;s mods directory, and you can create one if you do not have one already. This mod will not be available to the VFS when FNIS is run, so do not choose a mod you use for anything else. This setting can be updated in the Plugins tab of the Mod Organizer Settings menu.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
* **Better `.gitignore`** - a lower chance of accidentally committing the wrong stuff
* **`.editorconfig`** - VS 2017 tried changing my PEP-compliant spaces to tabs, upsetting the interpreter. This stops that. If it wasn't so much hassle, I'd add one of these to every Mod Organizer repo so that VS complies with the weird two-spaces whitespace policy of the C++ code. (I worked around this locally by just putting one in the directory above where I build MO.)
* **`pathlib`** - made it simpler to make the next set of changes.
* **Ask the user for confirmation before setting the output directory to a non-empty mod** - ensures the user has actually read the bit about using a mod just for FNIS output.
* **Remove leftover debug messages** - I thought I'd already got rid of them. The log clutter should be reduced.
* **Disable the mod temporarily while FNIS is running** - as discussed on Discord, this reduces the chance of something going horribly wrong.
* **`isActive()`** - once https://github.com/ModOrganizer2/modorganizer/issues/540 is resolved, should hide the plugin when not managing a game compatible with FNIS.
